### PR TITLE
Simplify build-python-package action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: Test
 
+# Limited unit testing of the actions
+
 on:
   pull_request:
 

--- a/build-python-package/action.yml
+++ b/build-python-package/action.yml
@@ -1,20 +1,12 @@
 name: Build Python package
-description: Build Python package wheel distribution. Can also be run in test mode.
+description: Build Python package wheel distribution. Must be run in the (usually top-level) package dir containing setup.py
 inputs:
   dry-run:
-    description: If true, merely test the build process in a temporary directory
+    description: Obsolete; there is no longer a difference between dry-run and real build
     required: false
     default: false
 runs:
   using: composite
   steps:
     - shell: bash
-      env:
-        IS_TEST: ${{ inputs.dry-run }}
-      run: |
-        if "$IS_TEST"; then
-          cd $( mktemp -d )
-          python3 "${{ github.workspace }}/setup.py" bdist_wheel
-        else
-          python3 setup.py bdist_wheel sdist
-        fi
+      run: python3 setup.py bdist_wheel sdist

--- a/stage-1/checkout-pr-branch/action.yml
+++ b/stage-1/checkout-pr-branch/action.yml
@@ -18,7 +18,6 @@ runs:
       run: |
         git config --global user.name "github-actions[bot]"
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
         git config push.default current
 
     - name: Create & checkout PR branch


### PR DESCRIPTION
No need to build the distribution in a temp dir when doing a test run