### PR TITLE
Fix "fatal: not in a git directory" error

### DIFF
--- a/configure-git/action.yml
+++ b/configure-git/action.yml
@@ -8,4 +8,4 @@ runs:
       run: |
         git config --global user.name "github-actions[bot]"
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config push.default current
+        git config push.default current || true  # won't work if cwd is not git repo


### PR DESCRIPTION
Currently causing nightly cylc-doc builds to fail https://github.com/cylc/cylc-doc/runs/1957476513?check_suite_focus=true