### PR TITLE
Ignore [bot] in grep for shortlog

### DIFF
--- a/check-shortlog/action.yml
+++ b/check-shortlog/action.yml
@@ -36,7 +36,7 @@ runs:
         git shortlog -s "${{ github.sha }}" \
             | awk '{$1=""; print substr($0,2) }' \
             | sort \
-            | grep -v 'github-actions\[bot\]' \
+            | grep -v '\[bot\]' \
             > shortlog
         cat shortlog
         echo "::endgroup::"


### PR DESCRIPTION
At the moment it ignores the github-actions[bot], but not the dependabot[bot]. I think this change will ignore any *[bot], which should be OK?