### PR TITLE
Deal with brackets after names

### DIFF
--- a/check-shortlog/action.yml
+++ b/check-shortlog/action.yml
@@ -19,6 +19,7 @@ runs:
         sed \
             -n \
             -e 's/ - //' \
+            -e 's/ (.*)//' \
             -e 's/^(//' -e 's/)$//' \
             -e '/start-shortlog/,${p;/end-shortlog/q}' \
             "${{ inputs.contributing_file }}" \


### PR DESCRIPTION
Required for https://github.com/metomi/rose/issues/2476

Metomi Rose lists contributors:
```markdown
- Timothy Pillinger (Instution)
```
Why causes failures in Check Contributors.
I've added an extra SED expression to remove text in brackets.