### PR TITLE
Add input for showing GH workflow badges in release PR

### DIFF
--- a/stage-1/create-release-pr/action.yml
+++ b/stage-1/create-release-pr/action.yml
@@ -1,6 +1,9 @@
 name: Create release pull request
 description: Commit, push and open release PR
-# NOTE: Needs GITHUB_TOKEN env variable (and HEAD_REF)
+# NOTE: Required env vars:
+# - GITHUB_TOKEN
+# - BASE_REF (set by stage-1/sanitize-inputs)
+# - HEAD_REF (set by stage-1/checkout-pr-branch)
 
 inputs:
   pr-label:
@@ -11,6 +14,9 @@ inputs:
     description: Commit message
     required: false
     default: 'Prepare release ${VERSION}'
+  test-workflows:
+    description: Comma delimited list of GH Actions workflow YAML files (including file extension) to display status badges
+    required: false
   commit-all:
     description: If true, stage all files before comitting
     required: false
@@ -20,10 +26,6 @@ inputs:
   #   required: false
 runs:
   using: composite
-  # main: index.js
-  # # Use outcome of push step from main workflow:
-  # post-if: always() && ! success() && steps.push.outcome == 'success'
-  # post: delete-branch.js  # On fail: delete PR branch on origin, if it was pushed
   steps:
     - name: Commit & push
       shell: bash
@@ -47,6 +49,7 @@ runs:
       working-directory: ${{ github.action_path }}
       env:
         PR_LABEL: ${{ inputs.pr-label }}
+        TEST_WORKFLOWS: ${{ inputs.test-workflows }}
       run: |
         echo "[command]Create release PR"
         node ./create-release-pr.js


### PR DESCRIPTION
Closes #14 

Add an input to the `stage-1/create-release-pr` action that allows you to specify GH Actions workflow files whose badges to show in the release PR.  This is in lieu of being able to trigger the test battery off a PR created by GH Actions.

#### Usage
```yaml
- name: Create pull request
  uses: cylc/release-actions/stage-1/create-release-pr@v1
  with:
      test-workflows: test_fast.yml, test_functional.yml, bash.yml, test_manylinux.yml
  env:
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

#### Demos

https://github.com/MetRonnie/cylc-flow/pull/7

![image](https://user-images.githubusercontent.com/61982285/131013944-eaa3d3f8-c724-4943-80f3-a973d1333301.png)

If you make a typo in the GH Actions workflow name, it will show as a broken link - e.g. https://github.com/MetRonnie/cylc-flow/pull/8

![image](https://user-images.githubusercontent.com/61982285/131014699-c7355488-7bb2-4170-8c77-3e71c62f6fed.png)

And if you don't provide the input, it won't show any badges but will still work, so this change is backwards compatible with v1 - https://github.com/MetRonnie/cylc-flow/pull/10

