### PR TITLE
Print emails in shortlog action for easier debugging

### DIFF
--- a/check-shortlog/action.yml
+++ b/check-shortlog/action.yml
@@ -33,14 +33,14 @@ runs:
     - name: List commit authors
       shell: bash
       run: |
-        echo '::group::List commit authors'
         git shortlog -s "${{ github.sha }}" \
             | awk '{$1=""; print substr($0,2) }' \
             | sort \
             | grep -v '\[bot\]' \
             > shortlog
-        cat shortlog
-        echo "::endgroup::"
+        echo '::group::List commit authors'
+        git shortlog -se
+        echo '::endgroup::'
 
     - name: See if they differ
       shell: bash


### PR DESCRIPTION
Improve debug-ibility of shortlog action

From Hilary on Element:
> Here's a curly one: Aaron David Cole and I ran into a problem with our "check contributor list" check on cylc-ui GitHub Actions (same test used in all cylc repos), which compares names in > CONTRIBUTING.md to author names listed by git shortlog with name aggregration via .mailmap.
> 
> The tableview PR branch kept failing the test with Juliano Serrao supposedly appearing in shortlog output but not in the CONTRIB file, even though all relevant commits on the > PR branch are correctly attributed to Giuliano Serrao in the mailmap, and git shortlog on the branch does not mention Juliano Serrao anywhere.
> 
> The reason:
> 
> - tests get run against a secret merge commit that GitHub creates as what would be the result if the PR is merged (i.e., not against the PR branch HEAD)
> - if the PR owner has not configured an email address on their GitHub profile, GitHub creates a gnarly "no-reply" address to go with the owner's GitHub name, as the author of > the secret merge commit
> 
> Once I realised this, I managed to find Giuliano's GitHub commit email address by cloning another of his repos and browsing the log:
> 
> > Juliano Serrao [80932386+giulianoserrao@users.noreply.github.com]
> 
> (Or, I could have tweaked the action recipe to print the result of git shortlog -e I think)