### PR TITLE
Only get dependabot PRs if necessary

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    versioning-strategy: increase-if-necessary
     labels:
       - 'dependencies'
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Turn off PRs if the new version already falls in the specified semver range (hopefully)

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy