### PR TITLE
Replace actions/create-release

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,7 @@
     "parserOptions": {
         "ecmaVersion": 2018
     },
-    "rules": {
-    }
+    "ignorePatterns": [
+        "!node_modules/cylc-action-utils.js"
+    ]
 }

--- a/create-release/action.yml
+++ b/create-release/action.yml
@@ -1,3 +1,16 @@
+# Copyright (c) 2018 GitHub, Inc. and contributors
+# Copyright (c) 2023 NIWA & British Crown (Met Office) & Contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
 name: Create GitHub release
 description: Mostly replicate actions/create-release (which is now unmaintained)
 # NOTE: Needs GITHUB_TOKEN env variable

--- a/create-release/action.yml
+++ b/create-release/action.yml
@@ -1,0 +1,53 @@
+name: Create GitHub release
+description: Mostly replicate actions/create-release (which is now unmaintained)
+# NOTE: Needs GITHUB_TOKEN env variable
+
+inputs:
+  tag_name:
+    description: 'The name of the tag.'
+    required: true
+  release_name:
+    description: 'The name of the release. For example, `Release v1.0.1`'
+    required: true
+  body:
+    description: 'Text describing the contents of the tag.'
+    required: false
+  body_path:
+    description: 'Path to file with information about the tag.'
+    required: false
+  draft:
+    description: '`true` to create a draft (unpublished) release, `false` to create a published one.'
+    required: false
+    default: false
+  prerelease:
+    description: '`true` to identify the release as a prerelease. `false` to identify the release as a full release.'
+    required: false
+    default: false
+  commitish:
+    description: 'Any branch or commit SHA the Git tag is created from, unused if the Git tag already exists. Default: SHA of current commit'
+    required: false
+  repo:
+    description: 'Repository on which to release. Used only if you want to create the release on another repo'
+    required: false
+
+outputs:
+  html_url:
+    description: 'The URL users can navigate to in order to view the release'
+    value: ${{ steps.main.outputs.html_url }}
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      id: main
+      env:
+        TAG: ${{ inputs.tag_name }}
+        REPO: ${{ inputs.repo || github.repository }}
+        TARGET: ${{ inputs.commitish || github.sha }}
+        TITLE: ${{ inputs.release_name }}
+        BODY: ${{ inputs.body }}
+        BODY_PATH: ${{ inputs.body_path }}
+        IS_DRAFT: ${{ inputs.draft }}
+        IS_PRERELEASE: ${{ inputs.prerelease }}
+      run: |
+        node ${{ github.action_path }}/create-release.js

--- a/create-release/create-release.js
+++ b/create-release/create-release.js
@@ -15,19 +15,18 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
 const {env} = process;
-const {writeFileSync} = require('fs');
-const {execSync} = require('cylc-action-utils');
+const {escSQ, execSync, setOutput} = require('cylc-action-utils');
 
 const cmd = [
     'gh', 'release', 'create',
     env.TAG,
     `--repo '${env.REPO}'`,
     `--target '${env.TARGET}'`,
-    `--title '${env.TITLE}'`,
+    `--title '${escSQ(env.TITLE)}'`,
 ]
 
 if (env.BODY) {
-    cmd.push(`--notes '${env.BODY.replace(/'/g, "&apos;")}'`)
+    cmd.push(`--notes '${escSQ(env.BODY)}'`)
 } else if (env.BODY_PATH) {
     cmd.push(`--notes-file '${env.BODY_PATH}'`)
 }
@@ -40,5 +39,4 @@ if (env.IS_PRERELEASE === 'true') {
 
 const url = execSync(cmd.join(' ')).split('\n')[0]
 
-// Set output
-writeFileSync(env.GITHUB_OUTPUT, `html_url=${url}`, {flag: 'a'})
+setOutput('html_url', url)

--- a/create-release/create-release.js
+++ b/create-release/create-release.js
@@ -1,0 +1,44 @@
+/* THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+const {env} = process;
+const {writeFileSync} = require('fs');
+const {execSync} = require('cylc-action-utils');
+
+const cmd = [
+    'gh', 'release', 'create',
+    env.TAG,
+    `--repo '${env.REPO}'`,
+    `--target '${env.TARGET}'`,
+    `--title '${env.TITLE}'`,
+]
+
+if (env.BODY) {
+    cmd.push(`--notes '${env.BODY.replace(/'/g, "&apos;")}'`)
+} else if (env.BODY_PATH) {
+    cmd.push(`--notes-file '${env.BODY_PATH}'`)
+}
+if (env.IS_DRAFT === 'true') {
+    cmd.push('--draft')
+}
+if (env.IS_PRERELEASE === 'true') {
+    cmd.push('--prerelease')
+}
+
+const url = execSync(cmd.join(' ')).split('\n')[0]
+
+// Set output
+writeFileSync(env.GITHUB_OUTPUT, `html_url=${url}`, {flag: 'a'})

--- a/node_modules/cylc-action-utils.js
+++ b/node_modules/cylc-action-utils.js
@@ -16,14 +16,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
 // Helpers for NodeJS steps in GitHub Actions
 
+const {env} = process;
 const {execSync} = require('child_process');
 const execSyncOpts = {stdio: 'pipe', encoding: 'utf8'};
+const {writeFileSync} = require('fs');
 
 exports.curlOpts = '--silent --fail --show-error';
 
-/** JSON.stringify() but escapes single quotes */
-exports.stringify = (obj) => {
-    return JSON.stringify(obj).replace(/'/g, "&apos;");
+/** Escape single quotes in string */
+exports.escSQ = (str) => {
+    return str.replace(/'/g, "&apos;")
 }
 
 /**
@@ -48,7 +50,7 @@ exports.execSync = (cmd, options = {}) => {
         console.log(`[command]${cmd}`);
         try {
             console.log(JSON.stringify(JSON.parse(stdout), null, 2));
-        } catch {
+        } catch (err) {
             console.log(stdout);
         }
         if (!options.verbose) {
@@ -58,14 +60,17 @@ exports.execSync = (cmd, options = {}) => {
     return stdout;
 };
 
+/** Set an environment variable for later steps in a workflow to use */
 exports.setEnv = (name, value) => {
-    // Set an environment variable for later steps in a workflow to use
-    const cmd = `echo "${name}=${value}" >> $GITHUB_ENV`;
-    execSync(cmd, execSyncOpts);
+    writeFileSync(env.GITHUB_ENV, `${name}=${value}\n`, {flag: 'a'})
 };
 
+/** Set a step's output */
+exports.setOutput = (name, value) => {
+    writeFileSync(env.GITHUB_OUTPUT, `${name}=${value}\n`, {flag: 'a'})
+};
+
+/** Add a path to $PATH */
 exports.addPath = (path) => {
-    // Add a path to $PATH
-    const cmd = `echo "${path}" >> $GITHUB_PATH`;
-    execSync(cmd, execSyncOpts);
+    writeFileSync(env.GITHUB_PATH, `${path}\n`, {flag: 'a'})
 };

--- a/node_modules/cylc-action-utils.js
+++ b/node_modules/cylc-action-utils.js
@@ -21,14 +21,19 @@ const execSyncOpts = {stdio: 'pipe', encoding: 'utf8'};
 
 exports.curlOpts = '--silent --fail --show-error';
 
+/** JSON.stringify() but escapes single quotes */
 exports.stringify = (obj) => {
-    // JSON.stringify() but escapes single quotes
     return JSON.stringify(obj).replace(/'/g, "&apos;");
 }
 
+/**
+ * Node's execSync() but with improved logging
+ *
+ * @param {string} cmd - The command to execute.
+ * @param {{ quiet: boolean, verbose: boolean }} options
+ * @return {string} - stdout
+ */
 exports.execSync = (cmd, options = {}) => {
-    // Node's execSync() but with improved logging
-    // options: quiet (bool), verbose (bool)
     let stdout;
     try {
         stdout = execSync(cmd, execSyncOpts);

--- a/stage-1/create-release-pr/action.yml
+++ b/stage-1/create-release-pr/action.yml
@@ -46,13 +46,12 @@ runs:
       id: create-pr
       shell: bash --noprofile --norc {0}
       # Note: not `-eo pipefail` as we need last step to run if this step fails
-      working-directory: ${{ github.action_path }}
       env:
         PR_LABEL: ${{ inputs.pr-label }}
         TEST_WORKFLOWS: ${{ inputs.test-workflows }}
       run: |
         echo "[command]Create release PR"
-        node ./create-release-pr.js
+        node "${GITHUB_ACTION_PATH}/create-release-pr.js"
 
         if [[ $? -eq 0 ]]; then
           echo "outcome=success" >> $GITHUB_OUTPUT

--- a/stage-1/create-release-pr/create-release-pr.js
+++ b/stage-1/create-release-pr/create-release-pr.js
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
 const {env} = process;
 const {readFileSync} = require('fs');
-const {execSync, curlOpts} = require('cylc-action-utils');
+const {escSQ, execSync, curlOpts} = require('cylc-action-utils');
 // Note: all string properties of the `github` context are available as env vars as `GITHUB_<PROPERTY>`
 // WARNING: Don't use ${env.GITHUB_TOKEN} in execSync() as that might print in log. Use `$GITHUB_TOKEN` instead.
 
@@ -71,7 +71,7 @@ const cmd = [
     `-H '${env.HEAD_REF}'`,
     `-B '${env.BASE_REF}'`,
     `-t 'Prepare release: ${env.VERSION}'`,
-    `-b '${bodyText.replace(/'/g, "&apos;")}'`,
+    `-b '${escSQ(bodyText)}'`,
     `-a '${author}'`,
 ];
 if (milestone) {

--- a/stage-1/create-release-pr/create-release-pr.js
+++ b/stage-1/create-release-pr/create-release-pr.js
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
 const {env} = process;
 const {readFileSync} = require('fs');
-const {execSync, stringify, curlOpts} = require('cylc-action-utils');
+const {execSync, curlOpts} = require('cylc-action-utils');
 // Note: all string properties of the `github` context are available as env vars as `GITHUB_<PROPERTY>`
 // WARNING: Don't use ${env.GITHUB_TOKEN} in execSync() as that might print in log. Use `$GITHUB_TOKEN` instead.
 
@@ -65,23 +65,23 @@ ${workflowBadges ? `- Tests last run on \`${env.BASE_REF}\`: ${workflowBadges.jo
 - After merging, the bot will comment below with a link to the release (if not, look at the PR checks tab)
 `;
 
-const payload = {
-    title: `Prepare release: ${env.VERSION}`,
-    head: env.HEAD_REF,
-    base: env.BASE_REF,
-    body: bodyText
-};
+const cmd = [
+    'gh', 'pr', 'create',
+    `-R '${env.GITHUB_REPOSITORY}'`,
+    `-H '${env.HEAD_REF}'`,
+    `-B '${env.BASE_REF}'`,
+    `-t 'Prepare release: ${env.VERSION}'`,
+    `-b '${bodyText.replace(/'/g, "&apos;")}'`,
+    `-a '${author}'`,
+];
+if (milestone) {
+    cmd.push(`-m '${milestone.title}'`)
+}
+if (env.PR_LABEL) {
+    cmd.push(`-l '${env.PR_LABEL}'`)
+}
 
-const request = `curl -X POST \
-    ${API_repoURL}/pulls \
-    -H "authorization: Bearer $GITHUB_TOKEN" \
-    -H "content-type: application/json" \
-    --data '${stringify(payload)}' \
-    ${curlOpts}`;
-
-const pr = JSON.parse(execSync(request));
-setMilestone_Assignee_Label(pr.number);
-
+execSync(cmd.join(' '));
 
 
 function getMilestone() {
@@ -106,23 +106,6 @@ function getMilestone() {
     }
     console.log(`::warning:: Could not find milestone matching "${env.VERSION}"`);
     return;
-}
-
-function setMilestone_Assignee_Label(prNumber) {
-    // Cannot set them when creating the PR unfortunately
-    const payload = {
-        milestone: milestone ? milestone.number : undefined,
-        assignees: [author],
-        labels: env.PR_LABEL ? [env.PR_LABEL] : undefined
-    }; // Note: stringify() below removes undefined properties
-
-    const request = `curl -X PATCH \
-        ${API_repoURL}/issues/${prNumber} \
-        -H "authorization: Bearer $GITHUB_TOKEN" \
-        -H "content-type: application/json" \
-        --data '${stringify(payload)}' \
-        ${curlOpts}`;
-    execSync(request);
 }
 
 function getTestWorkflowBadges() {

--- a/stage-2/bump-dev-version/action.yml
+++ b/stage-2/bump-dev-version/action.yml
@@ -77,7 +77,7 @@ runs:
         INPUT_BODY: |
           I have attempted to guess the next dev version.
           If it is not correct, please push to this branch.
-        REVIEWER: ${{ github.event.pull_request.sender.login }}
+        REVIEWER: ${{ github.event.pull_request.merged_by.login }}
       run: |
         gh pr create -R "$GITHUB_REPOSITORY" \
           -H "$INPUT_HEAD" -B "$INPUT_BASE" -t "$INPUT_TITLE" -b "$INPUT_BODY" \

--- a/stage-2/bump-dev-version/action.yml
+++ b/stage-2/bump-dev-version/action.yml
@@ -12,7 +12,11 @@ runs:
   steps:
     - name: Install utils
       shell: bash
-      run: python3 -m pip install -q packaging
+      run: python3 -m pip install packaging
+
+    - name: Install module
+      shell: bash
+      run: python3 -m pip install . -e
 
     - name: Configure git
       shell: bash

--- a/stage-2/comment-on-pr/comment-on-pr.js
+++ b/stage-2/comment-on-pr/comment-on-pr.js
@@ -16,7 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
 const {env} = process;
 const {readFileSync} = require('fs');
-const {execSync, stringify, curlOpts} = require('cylc-action-utils');
+const {execSync, escSQ, curlOpts} = require('cylc-action-utils');
 
 const pr_event = JSON.parse(readFileSync(env.GITHUB_EVENT_PATH)).pull_request;
 const author = pr_event.assignees[0].login;
@@ -80,7 +80,7 @@ execSync(`curl -X POST \
     ${pr_event.comments_url} \
     -H "authorization: Bearer $GITHUB_TOKEN" \
     -H "content-type: application/json" \
-    --data '${stringify(payload)}' \
+    --data '${escSQ(JSON.stringify(payload))}' \
     ${curlOpts}`
 );
 
@@ -96,7 +96,7 @@ function closeMilestone() {
                 https://api.github.com/repos/${env.GITHUB_REPOSITORY}/milestones/${pr_event.milestone.number} \
                 -H "authorization: Bearer $GITHUB_TOKEN" \
                 -H "content-type: application/json" \
-                --data '${stringify(payload)}' \
+                --data '${escSQ(JSON.stringify(payload))}' \
                 ${curlOpts}`
             );
             return true;
@@ -116,7 +116,7 @@ function updatePRTitle() {
         ${pr_event.url} \
         -H "authorization: Bearer $GITHUB_TOKEN" \
         -H "content-type: application/json" \
-        --data '${stringify(payload)}' \
+        --data '${escSQ(JSON.stringify(payload))}' \
         ${curlOpts}`
     );
 }


### PR DESCRIPTION
 - https://github.com/actions/create-release is archived and gives off deprecation warnings now, so I have implemented a drop-in replacement (some minor differences but performs identically for the way we use it)
 - I was having some problems with the `curl` POST request for creating a PR (`stage-1/create-release-pr`), so replaced it with gh CLI