### PR TITLE
Fix bump-dev-version (again)

### DIFF
--- a/stage-2/bump-dev-version/action.yml
+++ b/stage-2/bump-dev-version/action.yml
@@ -16,7 +16,7 @@ runs:
 
     - name: Install module
       shell: bash
-      run: python3 -m pip install . -e
+      run: python3 -m pip install -e .
 
     - name: Configure git
       shell: bash


### PR DESCRIPTION
Wrong order of args/options for `pip install -e .`