### PR TITLE
set meta release action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,3 +105,27 @@ jobs:
         exact_grep "## isodatetime 2.0.2 (<span actions:bind='release-date'>Released 2020-07-01</span>)" CHANGES.md
         # Check changes to changelog are staged
         exact_grep "M  CHANGES.md" <(git status -s)
+
+  test-set-meta-releases:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v2
+
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: run
+        id: test-set-meta-releases
+        uses: ./set-meta-releases
+
+      - name: check
+        shell: python
+        run: |
+          import json
+          meta_releases = json.loads('${{ steps.test-set-meta-releases.outputs.meta-releases }}')
+          assert isinstance(meta_releases, list)
+          assert len(meta_releases) > 0

--- a/set-meta-releases/action.yml
+++ b/set-meta-releases/action.yml
@@ -1,0 +1,38 @@
+name: Get Meta Releases
+description: |
+  Fetch the list of active meta releases.
+
+  The meta releases will be made available as a JSON list in the output
+  `meta-releases`.
+
+outputs:
+  meta-releases:
+    description: 'JSON list of meta release identifiers'
+    value: ${{ steps.set-meta-releases.outputs.meta-releases }}
+
+runs:
+  using: composite
+  steps:
+    - name: Configure Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+
+    - name: fetch branch file
+      shell: bash
+      run: |
+        wget https://raw.githubusercontent.com/cylc/cylc-admin/master/docs/status/branches.json
+
+    - id: set-meta-releases
+      shell: python
+      run: |
+        import json
+        import os
+        with open(os.environ['GITHUB_OUTPUT'], 'w+') as outputsfile:
+          with open('branches.json', 'r') as jsonfile:
+            branches = json.load(jsonfile)
+            print(
+            'meta-releases='
+              + json.dumps(list(branches['meta_releases'].keys())),
+              file=outputsfile,
+          )

--- a/set-meta-releases/action.yml
+++ b/set-meta-releases/action.yml
@@ -32,7 +32,7 @@ runs:
           with open('branches.json', 'r') as jsonfile:
             branches = json.load(jsonfile)
             print(
-            'meta-releases='
+              'meta-releases='
               + json.dumps(list(branches['meta_releases'].keys())),
               file=outputsfile,
-          )
+            )


### PR DESCRIPTION
Action for fetching the list of meta releases.

This can be used to define the test matrix as demonstrated in https://github.com/cylc/cylc-admin/pull/170.