### PR TITLE
Fix check-shortlog using wrong SHA on workflow_dispatch

### DIFF
--- a/check-shortlog/action.yml
+++ b/check-shortlog/action.yml
@@ -15,7 +15,6 @@ runs:
     - name: Get known contributors from contributing file
       shell: bash
       run: |
-        echo '::group::Get known contributors from contributing file'
         sed \
             -n \
             -e 's/ - //' \
@@ -27,19 +26,20 @@ runs:
             | tail -n +2 \
             | sort \
             > contributors
+        echo '::group::Contributors from contributing file:'
         cat contributors
         echo "::endgroup::"
 
     - name: List commit authors
       shell: bash
       run: |
-        git shortlog -s "${{ github.sha }}" \
+        git shortlog -s HEAD \
             | awk '{$1=""; print substr($0,2) }' \
             | sort \
             | grep -v '\[bot\]' \
             > shortlog
-        echo '::group::List commit authors'
-        git shortlog -se
+        echo '::group::Commit authors:'
+        git shortlog -se HEAD
         echo '::endgroup::'
 
     - name: See if they differ


### PR DESCRIPTION
If you do a workflow_dispatch, then `${{ github.sha }}` is the branch for the version of the workflow YAML file that was used (master by default). However, we do use the action with non-master branches checked out

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).