### PR TITLE
`build-python-package`: do a dependencies check

### DIFF
--- a/build-python-package/action.yml
+++ b/build-python-package/action.yml
@@ -30,3 +30,7 @@ runs:
       run: |
         python3 -m pip install twine
         twine check dist/*
+
+    - name: Check dependencies
+      shell: bash
+      run: python3 -m pip install -e . --dry-run --ignore-installed

--- a/build-python-package/action.yml
+++ b/build-python-package/action.yml
@@ -33,4 +33,4 @@ runs:
 
     - name: Check dependencies
       shell: bash
-      run: python3 -m pip install -e . --dry-run --ignore-installed
+      run: python3 -m pip install -e .[all] --dry-run --ignore-installed


### PR DESCRIPTION
I think this should catch the case where we pin to an unreleased dependency.

E.g. last time we thought we weren't going to release `rose-2.1.0` but we released `cylc-rose` with a dependency on `rose==2.1.*` and no part of the CI chain failed