### PR TITLE
`build-python-package`: make dependencies check optional

### DIFF
--- a/build-python-package/action.yml
+++ b/build-python-package/action.yml
@@ -1,6 +1,10 @@
 name: Build Python package
 description: Build Python package wheel distribution. Must be run in the (usually top-level) package dir containing setup.py
 inputs:
+  check-dependencies:
+    description: Try pip-installing dependencies to make sure we are pinned to released versions on PyPI
+    required: false
+    default: true
   dry-run:
     description: Obsolete; there is no longer a difference between dry-run and real build
     required: false
@@ -32,5 +36,6 @@ runs:
         twine check dist/*
 
     - name: Check dependencies
+      if: inputs.check-dependencies
       shell: bash
       run: python3 -m pip install -e .[all] --dry-run --ignore-installed


### PR DESCRIPTION
In some repos we are using `build-python-package` separately from the release process so the new check added in #54 will fail as the pinned version of cylc-flow is unreleased so not yet on PyPI