### PR TITLE
set-meta-releases: output whole dict of branch info

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,11 @@ jobs:
         shell: python
         run: |
           import json
-          meta_releases = json.loads('${{ steps.test-set-meta-releases.outputs.meta-releases }}')
-          assert isinstance(meta_releases, list)
-          assert len(meta_releases) > 0
+
+          meta_releases_list = json.loads('${{ steps.test-set-meta-releases.outputs.meta-releases }}')
+          assert isinstance(meta_releases_list, list)
+          assert len(meta_releases_list) > 0
+
+          meta_releases_dict = json.loads('${{ steps.test-set-meta-releases.outputs.meta-releases-dict }}')
+          assert isinstance(meta_releases_dict, dict)
+          assert len(meta_releases_dict) > 0

--- a/set-meta-releases/action.yml
+++ b/set-meta-releases/action.yml
@@ -7,8 +7,11 @@ description: |
 
 outputs:
   meta-releases:
-    description: 'JSON list of meta release identifiers'
-    value: ${{ steps.set-meta-releases.outputs.meta-releases }}
+    description: JSON list of meta release identifiers
+    value: ${{ steps.set-meta-releases.outputs.list }}
+  meta-releases-dict:
+    description: JSON dictionary of branches for each meta release
+    value: ${{ steps.set-meta-releases.outputs.dict }}
 
 runs:
   using: composite
@@ -32,7 +35,10 @@ runs:
           with open('branches.json', 'r') as jsonfile:
             branches = json.load(jsonfile)
             print(
-              'meta-releases='
-              + json.dumps(list(branches['meta_releases'].keys())),
-              file=outputsfile,
+              f"list={json.dumps(list(branches['meta_releases'].keys()))}",
+              file=outputsfile
+            )
+            print(
+              f"dict={json.dumps(branches['meta_releases'])}",
+              file=outputsfile
             )


### PR DESCRIPTION
Supersedes #58, allows us to checkout the correct version of cylc-doc in the nightly runs.

Example dict output
```json
{
    "8.2": {
        "cylc/cylc-flow": "8.2.x",
        "cylc/cylc-doc": "8.2.x",
        "cylc/cylc-rose": "1.3.x",
        "cylc/cylc-uiserver": "1.4.x",
        "metomi/rose": "2.1.x"
    },
    "8.2-jps-v1": {
        "cylc/cylc-flow": "8.2.x",
        "cylc/cylc-doc": "8.2.x",
        "cylc/cylc-rose": "1.3.x",
        "cylc/cylc-uiserver": "1.3.x",
        "metomi/rose": "2.1.x"
    },
    "8.3": {
        "cylc/cylc-flow": "master",
        "cylc/cylc-doc": "master",
        "cylc/cylc-rose": "master",
        "cylc/cylc-uiserver": "master",
        "metomi/rose": "master"
    }
}
```
