### PR TITLE
Fix set-python-package-version for Python 3.12

### DIFF
--- a/.github/test_files/__init__.py
+++ b/.github/test_files/__init__.py
@@ -1,3 +1,5 @@
 # THIS IS A TEST FILE
 
 __version__ = "2.0.2"
+
+FULL_VERSION = f"1!{__version__}"

--- a/.github/test_files/pyproject.toml
+++ b/.github/test_files/pyproject.toml
@@ -1,0 +1,15 @@
+# THIS IS A TEST FILE
+
+[project]
+name = "test-project"
+description = "This is a test project"
+dynamic = ["version"]
+
+[tool.setuptools]
+platforms = ["any"]
+
+[tool.setuptools.dynamic]
+version = {attr = ".FULL_VERSION"}
+
+[tool.setuptools.packages.find]
+include = ["*"]

--- a/.github/test_files/setup.cfg
+++ b/.github/test_files/setup.cfg
@@ -2,5 +2,8 @@
 
 [metadata]
 name = test-project
-version = attr: .__version__
+version = attr: .FULL_VERSION
 description = This is a test project
+
+[options]
+packages = find_namespace:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        pep517: [true, false]
+        project-file: ['setup.py', 'setup.cfg', 'pyproject.toml']
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
@@ -86,11 +86,7 @@ jobs:
       run: |
         cp .github/test_files/__init__.py ./__init__.py
         cp .github/test_files/CHANGES.md ./CHANGES.md
-        if ${{ matrix.pep517 }}; then
-          cp .github/test_files/setup.cfg ./setup.cfg
-        else
-          cp .github/test_files/setup.py ./setup.py
-        fi
+        cp .github/test_files/${{ matrix.project-file }} ./${{ matrix.project-file }}
 
         echo "[command]git add ."; git add .
         echo "[command]git commit"
@@ -111,14 +107,7 @@ jobs:
         assert __version__ == '9.2.3', f'::error:: assert version {__version__} == 9.2.3'
         "
         package_version='${{ steps.set-package-version.outputs.package-version }}'
-        # In setup.py projects, the __init__.py __version__ may be different to the setup.py version
-        # but in PEP 517 projects, the setup.cfg version will be the same as __init__.py __version__
-        if ${{ matrix.pep517 }}; then
-          expected_version="9.2.3"
-        else
-          expected_version="1!9.2.3"
-        fi
-        assert_equal "$package_version" "$expected_version"
+        assert_equal "$package_version" "1!9.2.3"
         # Check changes to init file are staged
         exact_grep "M  __init__.py" <(git status -s)
 

--- a/stage-1/set-python-package-version/action.yml
+++ b/stage-1/set-python-package-version/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: Install utils
       shell: bash
       run: |
-        python3 -m pip install -q packaging
+        python3 -m pip install -q setuptools packaging
         echo "${{ github.action_path }}/../../bin" >> $GITHUB_PATH  # Note: this persists in the workflow after the action is called
 
     - name: Update version in __init__.py
@@ -65,9 +65,7 @@ runs:
         else
           # shim to get the project version from a PEP517 project
           echo "PEP 517 project detected"
-          echo 'from setuptools import setup; setup()' > setup.py
-          package_version=$( python setup.py --version )
-          rm setup.py
+          package_version=$( python -c 'from setuptools import setup; setup()' --version )
         fi
         # Check version number is valid:
         cmp_py_versions "$package_version" "$package_version"


### PR DESCRIPTION
Fix
```
ModuleNotFoundError: No module named 'setuptools'
```

![image](https://github.com/cylc/release-actions/assets/61982285/025bdd39-1077-4f5d-a4fd-d9f3cd8550a9)

Also ensure we are testing `pyproject.toml` projects
