### PR TITLE
Install setuptools for building python packages

### DIFF
--- a/build-python-package/action.yml
+++ b/build-python-package/action.yml
@@ -19,7 +19,7 @@ runs:
           # old style setup.py project
           # (must manually install build dependencies)
           echo "setup.py detected"
-          python3 -m pip install wheel
+          python3 -m pip install wheel setuptools
           python3 setup.py bdist_wheel sdist
         else
           # PEP517 project


### PR DESCRIPTION
In Python 3.12, setuptools is longer included by default in environments

> [gh-95299](https://github.com/python/cpython/issues/95299): Do not pre-install setuptools in virtual environments created with [venv](https://docs.python.org/3/library/venv.html#module-venv). This means that distutils, setuptools, pkg_resources, and easy_install will no longer available by default; to access these run pip install setuptools in the [activated](https://docs.python.org/3/library/venv.html#venv-explanation) virtual environment.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
