### PR TITLE
Add action for towncrier build draft changelog

### DIFF
--- a/towncrier-draft/action.yml
+++ b/towncrier-draft/action.yml
@@ -1,0 +1,29 @@
+name: Towncrier - draft changelog
+description: Draft the changelog for the next release. Write the output to the GH Actions job summary.
+
+runs:
+  using: composite
+  steps:
+    - name: Install Towncrier if needed
+      shell: bash
+      run: python3 -m pip install -q towncrier
+
+    - name: Get package version if NodeJS project
+      id: node
+      shell: bash
+      run: |
+        if [[ -f package.json ]]; then
+          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Draft changelog
+      shell: bash
+      env:
+        VER: ${{ steps.node.outputs.version }}
+      run: |
+        CMD="towncrier build --draft --date=CCYY-MM-DD"
+        if [[ -n "$VER" ]]; then
+          CMD="$CMD --version $VER"
+        fi
+        echo -e "# Draft changelog\n" >> "$GITHUB_STEP_SUMMARY"
+        $CMD | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
It's kind of useful to be able to see the rendered changelog.

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary

To see it, you can go to the Actions summary page https://github.com/cylc/cylc-ui/actions/runs/9082240185#summary-24958150609

![image](https://github.com/cylc/cylc-ui/assets/61982285/7329b788-0ee8-452e-85ba-1db8e7f414b3)

#### Check List

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
