### PR TITLE
Remove changelog checklist item from release process

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+#### Description
+<!-- Please explain the changes made -->
+
+
+#### Checklist
+
+- [ ] I have read the contributing instructions in `README.md` and have opened this against the correct branch & milestone

--- a/.github/workflows/branch-sync.yml
+++ b/.github/workflows/branch-sync.yml
@@ -102,7 +102,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BODY: |
-            Please do a **normal merge**, not squash merge.
+            > [!IMPORTANT]
+            > Please do a **normal merge**, not squash merge.
+
             Please fix conflicts if necessary.
 
             ---

--- a/stage-1/create-release-pr/create-release-pr.js
+++ b/stage-1/create-release-pr/create-release-pr.js
@@ -55,9 +55,6 @@ ${workflowBadges ? `- Tests last run on \`${env.BASE_REF}\`:\n    ${workflowBadg
 
 #### Checklist:
 - ${milestoneText()}
-- [ ] Changelog up-to-date?
-  - Examine pull requests made since the last release
-  - "Released on" date updated? ${env.CHANGELOG_DATE ? `✔️ \`${env.CHANGELOG_DATE}\`` : `⚠️ couldn't automatically set date`}
 
 #### Next steps:
 - @${author} should request 1 or 2 reviews


### PR DESCRIPTION
#### Description

Changelog entries are already a per-PR checklist item. GH Actions automatically sets changelog release date during release.

Also added custom PR template for this repo

#### Checklist

- [x] I have read the contributing instructions in `README.md` and have opened this against the correct branch & milestone
