### PR TITLE
Bypass picking compatible branches if branches already specified

### DIFF
--- a/install-cylc-components/action.yml
+++ b/install-cylc-components/action.yml
@@ -84,6 +84,12 @@ runs:
         cat branches.json
 
     - name: Determine compatible Cylc component versions
+      # Need string comparison for bools: https://github.com/actions/runner/issues/2238
+      if: >-
+        (inputs.cylc_flow == 'true' && !inputs.cylc_flow_tag) ||
+        (inputs.cylc_uiserver =='true' && !inputs.cylc_uiserver_tag) ||
+        (inputs.metomi_rose == 'true' && !inputs.metomi_rose_tag) ||
+        (inputs.cylc_rose == 'true' && !inputs.cylc_rose_tag)
       id: get_tag
       shell: bash
       env:


### PR DESCRIPTION
#### Description

This allows manually running workflows from forks where the repo names will not match the cylc-admin meta-release info


#### Checklist

- [x] I have read the contributing instructions in `README.md` and have opened this against the correct branch & milestone
