### PR TITLE
towncrier: use login shell

### DIFF
--- a/towncrier-draft/action.yml
+++ b/towncrier-draft/action.yml
@@ -5,19 +5,19 @@ runs:
   using: composite
   steps:
     - name: Install Towncrier if needed
-      shell: bash
+      shell: bash -elo pipefail {0}
       run: python3 -m pip install -q towncrier
 
     - name: Get package version if NodeJS project
       id: node
-      shell: bash
+      shell: bash -elo pipefail {0}
       run: |
         if [[ -f package.json ]]; then
           echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Draft changelog
-      shell: bash
+      shell: bash -elo pipefail {0}
       env:
         VER: ${{ steps.node.outputs.version }}
       run: |


### PR DESCRIPTION
* It looks like towncrier tries to import the Python package being documented for some reason.
* Use the login shell to pick up bash_profile stuffs.
