### PR TITLE
Towncrier draft: fix version undefined

### DIFF
--- a/towncrier-draft/action.yml
+++ b/towncrier-draft/action.yml
@@ -15,7 +15,7 @@ runs:
       shell: bash -elo pipefail {0}
       run: |
         if [[ -f package.json ]]; then
-          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+          echo "version=$(node -p "require('./package.json').version ?? ''")" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Draft changelog


### PR DESCRIPTION
#### Description
metomi-rose has a `package.json` which causes the draft output to have version "undefined".


#### Checklist

- [x] I have read the contributing instructions in `README.md` and have opened this against the correct branch & milestone
