### PR TITLE
branch sync: trickle bugfixes up the release branches

### DIFF
--- a/.github/workflows/branch-sync.yml
+++ b/.github/workflows/branch-sync.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      BASE_BRANCH: master
       HEAD_BRANCH: ${{ inputs.head_branch || github.ref_name }}
       STATUS_JSON: https://raw.githubusercontent.com/cylc/cylc-admin/master/docs/status/branches.json
       FORCE_COLOR: 2
@@ -44,14 +43,41 @@ jobs:
             print(f'HEAD_BRANCH={branch}', file=F)
             print(f'SYNC_BRANCH={branch}-sync', file=F)
 
+      - name: Configure git
+        uses: cylc/release-actions/configure-git@v1
+
+      - name: Determine base branch
+        id: get-base-branch
+        run: |
+          # Determine which branch to merge into, e.g:
+          # * if a change is made to 1.2.x, merge it into 1.3.x;
+          # * if a change is made to 1.3.x, merge it into 1.4.x;
+          # * if a change is made to 1.4.x, merge it into master.
+
+          # default to the HEAD branch (typically either master or main)
+          base_branch=$(git remote show origin | sed -n 's/.*HEAD branch: \(.*\)/\1/p')
+          isnext=false
+
+          # Run through bugfix branches in order, e.g. 1.2.x, 1.3.x, 1.4.x.
+          for branch in $(git ls-remote --branches origin '*.x' | sed -n 's/.*refs\/heads\/\(.*\)/\1/p' | sort); do
+            if [[ $branch == $HEAD_BRANCH ]]; then
+              # This is the HEAD branch (the one with the new changes), we
+              # should merge into the following bugfix branch.
+              isnext=true
+            elif $isnext; then
+              # Merge into this branch.
+              base_branch="$branch"
+              break
+            fi
+          done
+          echo "BASE_BRANCH=$branch" >> "$GITHUB_OUTPUT"
+          echo "BASE_BRANCH=$branch" >> "$GITHUB_ENV"
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: master
-
-      - name: Configure git
-        uses: cylc/release-actions/configure-git@v1
+          ref: ${{ steps.get-base-branch.BASE_BRANCH }}
 
       - name: Checkout sync branch if it exists
         continue-on-error: true

--- a/.github/workflows/branch-sync.yml
+++ b/.github/workflows/branch-sync.yml
@@ -55,7 +55,7 @@ jobs:
           # * if a change is made to 1.4.x, merge it into master.
 
           # default to the HEAD branch (typically either master or main)
-          base_branch=$(git remote show origin | sed -n 's/.*HEAD branch: \(.*\)/\1/p')
+          base_branch=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
           isnext=false
 
           # Run through bugfix branches in order, e.g. 1.2.x, 1.3.x, 1.4.x.
@@ -70,14 +70,13 @@ jobs:
               break
             fi
           done
-          echo "BASE_BRANCH=$branch" >> "$GITHUB_OUTPUT"
-          echo "BASE_BRANCH=$branch" >> "$GITHUB_ENV"
+          echo "BASE_BRANCH=$base_branch" >> "$GITHUB_ENV"
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ steps.get-base-branch.BASE_BRANCH }}
+          ref: ${{ env.BASE_BRANCH }}
 
       - name: Checkout sync branch if it exists
         continue-on-error: true


### PR DESCRIPTION
[Low priority until 8.6.0 is released]

It is likely that the 8.6.x branch will continue development post 8.7.0 release, so it's time to exercise our release branch system for real!

At present the branch sync will only sync into master, with this PR it will pick the next sequential release branch instead, defaulting to master once release branches have been exhausted.

Ideally:
1. When we merge a fix into 8.6.x, we will get a sync PR against 8.7.x.
2. When we merge that sync PR, we will get another sync PR against master.

I'm not sure whether the (2) will happen automatically or not though?

I'm also not sure how to test this.