### PR TITLE
Fix lack of token for step involving GH CLI

### DIFF
--- a/.github/workflows/branch-sync.yml
+++ b/.github/workflows/branch-sync.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Determine base branch
         id: get-base-branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Determine which branch to merge into, e.g:
           # * if a change is made to 1.2.x, merge it into 1.3.x;


### PR DESCRIPTION
#### Description

Follow-up to #112; every step that uses GH CLI needs to include the `GITHUB_TOKEN`


#### Checklist

- [x] I have read the contributing instructions in `README.md` and have opened this against the correct branch & milestone
