### PR TITLE
Fix configure-git.sh

### DIFF
--- a/configure-git/configure-git.sh
+++ b/configure-git/configure-git.sh
@@ -20,4 +20,4 @@ git config --global user.name "github-actions[bot]"
 git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 git config push.default current || true  # won't work if cwd is not git repo
 
-git config set advice.diverging false
+git config --global advice.diverging false


### PR DESCRIPTION
#### Description

Follow-up to #116 

`git config` without the `--global` option fails when used before checkout 🤦


#### Checklist

- [x] I have read the contributing instructions in `README.md` and have opened this against the correct branch & milestone
