### PR TITLE
branch_sync: add pattern for ignoring branches

### DIFF
--- a/.github/workflows/branch-sync.yml
+++ b/.github/workflows/branch-sync.yml
@@ -8,6 +8,9 @@ on:
       head_branch:
         type: string
         required: false
+      ignore_branches:
+        type: string
+        required: false
 
 jobs:
   sync:
@@ -71,6 +74,9 @@ jobs:
               # This is the HEAD branch (the one with the new changes), we
               # should merge into the following bugfix branch.
               isnext=true
+            elif [[ -n "${{ inputs.ignore_branches }}" ]] && grep -E "${{ inputs.ignore_branches }} <<< "$branch" 2>/dev/null; then
+              # This branch is excluded by the provied pattern
+              continue
             elif $isnext; then
               # Merge into this branch.
               base_branch="$branch"

--- a/.github/workflows/branch-sync.yml
+++ b/.github/workflows/branch-sync.yml
@@ -11,6 +11,7 @@ on:
       ignore_branches:
         type: string
         required: false
+        default: ''
 
 jobs:
   sync:
@@ -74,7 +75,7 @@ jobs:
               # This is the HEAD branch (the one with the new changes), we
               # should merge into the following bugfix branch.
               isnext=true
-            elif [[ -n "${{ inputs.ignore_branches }}" ]] && grep -E "${{ inputs.ignore_branches }} <<< "$branch" 2>/dev/null; then
+            elif [[ -n "${{ inputs.ignore_branches }}" ]] && grep -qE "${{ inputs.ignore_branches }} <<< "$branch"; then
               # This branch is excluded by the provied pattern
               continue
             elif $isnext; then


### PR DESCRIPTION
Rose is getting unwanted branch sync PRs:

https://github.com/metomi/rose/pull/2917

Because 2019 sorts after 2.x.

Add an input to specify a branch pattern to ignore.