### PR TITLE
Branch sync: ensure workflows do not run concurrently

### DIFF
--- a/.github/workflows/branch-sync.yml
+++ b/.github/workflows/branch-sync.yml
@@ -13,6 +13,10 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: sync-${{ inputs.head_branch || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Description

It has occurred to me that we do not want concurrent runs of the branch sync workflow for the same head branch.

This change ensures runs are queued. If a queued run has not started and another push happens on the head branch, the queued one will be cancelled (but not a running one).

#### Checklist

- [x] I have read the contributing instructions in `README.md` and have opened this against the correct branch & milestone
