### PR TITLE
Allow specifying of branch in `install-cylc-components`

### DIFF
--- a/install-cylc-components/action.yml
+++ b/install-cylc-components/action.yml
@@ -12,6 +12,11 @@ inputs:
       being merged into else the branch the workflow is being run against.
     required: false
     default: AUTO
+  branch:
+    description: |
+      The branch to use when determining compatible versions, if running
+      in workflow dispatch.
+    required: false
 
   cylc_flow:
     description: Install cylc-flow (default=true)
@@ -96,7 +101,7 @@ runs:
       shell: bash -elo pipefail {0}
       env:
         META_RELEASE: ${{ inputs.meta_release }}
-        BASE_BRANCH: ${{ github.base_ref || github.ref }}
+        BASE_BRANCH: ${{ inputs.branch || github.base_ref || github.ref }}
         REPOSITORY: ${{ github.repository }}
       run: "${{ github.action_path }}/../bin/pick_compatible_branches"
 


### PR DESCRIPTION
#### Description

When running in workflow dispatch, the base ref may not be correct as you may be using the workflow from `master` but have specified e.g. the `metomi/rose` branch `2.6.x`.

Tested here (although I missed the need to update docs job which failed as a result): https://github.com/MetRonnie/rose/actions/runs/19633941070


#### Checklist

- [x] I have read the contributing instructions in `README.md` and have opened this against the correct branch & milestone
