### PR TITLE
Allow users to specify pip installing cylc packages in editable mode …

### DIFF
--- a/install-cylc-components/action.yml
+++ b/install-cylc-components/action.yml
@@ -17,6 +17,12 @@ inputs:
       The branch to use when determining compatible versions, if running
       in workflow dispatch.
     required: false
+  editable_installations:
+    description: |
+      Install repositories in editable mode.
+      This may be useful for running coverage.
+    default: false
+    required: false
 
   cylc_flow:
     description: Install cylc-flow (default=true)
@@ -113,28 +119,38 @@ runs:
         meto_rose: ${{ inputs.metomi_rose_tag   || steps.get_tag.outputs.rose }}
         cylc_rose: ${{ inputs.cylc_rose_tag     || steps.get_tag.outputs.cylc_rose }}
       run: |
-        REQS=requirement.txt
-        touch "$REQS"
-        if [[ ${{ inputs.cylc_flow }} == true ]]; then
-          echo \
-            "cylc-flow[${{ inputs.cylc_flow_opts }}] @ git+https://github.com/${{ inputs.cylc_flow_repo }}@${cylc_flow}" \
-            >> "$REQS"
-        fi
-        if [[ ${{ inputs.cylc_uiserver }} == true ]]; then
-          echo \
-            "cylc-uiserver[${{ inputs.cylc_uiserver_opts }}] @ git+https://github.com/${{ inputs.cylc_uiserver_repo }}@${cylc_uis}" \
-            >> "$REQS"
-        fi
-        if [[ ${{ inputs.metomi_rose }} == true ]]; then
-          echo \
-            "metomi-rose[${{ inputs.metomi_rose_opts }}] @ git+https://github.com/${{ inputs.metomi_rose_repo }}@${meto_rose}" \
-            >> "$REQS"
-        fi
-        if [[ ${{ inputs.cylc_rose }} == true ]]; then
-          echo \
-            "cylc-rose[${{ inputs.cylc_rose_opts }}] @ git+https://github.com/${{ inputs.cylc_rose_repo }}@${cylc_rose}" \
-            >> "$REQS"
+        ARGS=()
+
+        if [[ ${{ inputs.editable_installations }} == true ]]; then
+          EDITABLE="--editable"
+        else
+          EDITABLE=''
         fi
 
-        cat "$REQS"
-        pip install -r "$REQS"
+        if [[ ${{ inputs.cylc_flow }} == true ]]; then
+          if [[ ${{ inputs.editable_installations }} == true ]]; then
+            ARGS+=("--editable")
+          fi
+          ARGS+=("git+https://github.com/${{ inputs.cylc_flow_repo }}@${cylc_flow}#egg=cylc-flow[${{ inputs.cylc_flow_opts }}]")
+        fi
+        if [[ ${{ inputs.cylc_uiserver }} == true ]]; then
+          if [[ ${{ inputs.editable_installations }} == true ]]; then
+            ARGS+=("--editable")
+          fi
+          ARGS+=("git+https://github.com/${{ inputs.cylc_uiserver_repo }}@${cylc_uiserver}#egg=cylc-uiserver[${{ inputs.cylc_uiserver_opts }}]")
+        fi
+        if [[ ${{ inputs.metomi_rose }} == true ]]; then
+          if [[ ${{ inputs.editable_installations }} == true ]]; then
+            ARGS+=("--editable")
+          fi
+        ARGS+=("git+https://github.com/${{ inputs.metomi_rose_repo }}@${metomi_rose}#egg=metomi-rose[${{ inputs.metomi_rose_opts }}]")
+        fi
+        if [[ ${{ inputs.cylc_rose }} == true ]]; then
+          if [[ ${{ inputs.editable_installations }} == true ]]; then
+            ARGS+=("--editable")
+          fi
+          ARGS+=("git+https://github.com/${{ inputs.cylc_rose_repo }}@${cylc_rose}#egg=cylc-rose[${{ inputs.cylc_rose_opts }}]")
+        fi
+
+        echo "${ARGS[@]}"
+        pip install "${ARGS[@]}"

--- a/install-cylc-components/action.yml
+++ b/install-cylc-components/action.yml
@@ -152,5 +152,5 @@ runs:
           ARGS+=("git+https://github.com/${{ inputs.cylc_rose_repo }}@${cylc_rose}#egg=cylc-rose[${{ inputs.cylc_rose_opts }}]")
         fi
 
-        echo "${ARGS[@]}"
+        echo "pip install ${ARGS[@]}"
         pip install "${ARGS[@]}"

--- a/install-cylc-components/action.yml
+++ b/install-cylc-components/action.yml
@@ -121,12 +121,6 @@ runs:
       run: |
         ARGS=()
 
-        if [[ ${{ inputs.editable_installations }} == true ]]; then
-          EDITABLE="--editable"
-        else
-          EDITABLE=''
-        fi
-
         if [[ ${{ inputs.cylc_flow }} == true ]]; then
           if [[ ${{ inputs.editable_installations }} == true ]]; then
             ARGS+=("--editable")


### PR DESCRIPTION
…to allow coverage checking

#### Description
Whilst setting up coverage for Cylc Functional style tests for [cylc review
](https://github.com/cylc/cylc-uiserver/pull/755) I found that editable installs are required.

Annoyingly the [issue for the deprecation warning](https://github.com/pypa/pip/issues/13157) for the old `egg=` syntax contains the following:

> [!WARNING]
> Editable VCS installs do NOT yet support the Direct URL syntax. This means the egg fragment is the only supported way to request an extra for a VCS URL. If this is your situation, you will need to wait until pip adds Direct URL support for editable VCS installs. We will NOT remove support for URLs with invalid egg fragments until there is a supported alternative for all use-cases.

#### Checklist

- [x] I have read the contributing instructions in `README.md` and have opened this against the correct branch & milestone
