### PR TITLE
Install cylc components: local_source option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,7 +184,7 @@ jobs:
             python=3.10
 
       - name: checkout rose
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: metomi/rose
           ref: 2.4.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,13 +183,22 @@ jobs:
           create-args:
             python=3.10
 
+      - name: checkout rose
+        uses: actions/checkout@v6
+        with:
+          repository: metomi/rose
+          ref: 2.4.0
+          path: metomi-rose
+
       - name: install-cylc-components
         uses: ./install-cylc-components
         with:
           cylc_flow: true
           cylc_flow_tag: 8.4.0
+          local_source: ./metomi-rose[lint]
 
       - name: test
-        shell: bash -elo pipefail {0}
+        shell: bash -xelo pipefail {0}
         run: |
           [[ $(cylc version) == 8.4.0 ]]
+          [[ $(rose version) == 'rose 2.4.0' ]]

--- a/install-cylc-components/action.yml
+++ b/install-cylc-components/action.yml
@@ -23,6 +23,17 @@ inputs:
       This may be useful for running coverage.
     default: false
     required: false
+  local_source:
+    description: |
+      Optional: The path of a local Python package to install.
+
+      E.g, to install Rose along with Cylc you might use:
+      * `cylc_flow=True`.
+      * `local_source=./metomi-rose`.
+
+      Dou may use `pip` options here, e.g: `-e=./metomi-rose[lint]`.
+    default: false
+    required: false
 
   cylc_flow:
     description: Install cylc-flow (default=true)
@@ -121,29 +132,35 @@ runs:
       run: |
         ARGS=()
 
-        if [[ ${{ inputs.cylc_flow }} == true ]]; then
-          if [[ ${{ inputs.editable_installations }} == true ]]; then
+        if ${{ inputs.cylc_flow }}; then
+          if ${{ inputs.editable_installations }}; then
             ARGS+=("--editable")
           fi
           ARGS+=("cylc-flow[${{ inputs.cylc_flow_opts }}]@git+https://github.com/${{ inputs.cylc_flow_repo }}@${cylc_flow}#egg=cylc-flow")
         fi
-        if [[ ${{ inputs.cylc_uiserver }} == true ]]; then
-          if [[ ${{ inputs.editable_installations }} == true ]]; then
+        if ${{ inputs.cylc_uiserver }}; then
+          if ${{ inputs.editable_installations }}; then
             ARGS+=("--editable")
           fi
           ARGS+=("cylc-uiserver[${{ inputs.cylc_uiserver_opts }}]@git+https://github.com/${{ inputs.cylc_uiserver_repo }}@${cylc_uis}#egg=cylc-uiserver")
         fi
-        if [[ ${{ inputs.metomi_rose }} == true ]]; then
-          if [[ ${{ inputs.editable_installations }} == true ]]; then
+        if ${{ inputs.metomi_rose }}; then
+          if ${{ inputs.editable_installations }}; then
             ARGS+=("--editable")
           fi
           ARGS+=("metomi-rose[${{ inputs.metomi_rose_opts }}]@git+https://github.com/${{ inputs.metomi_rose_repo }}@${meto_rose}#egg=metomi-rose")
         fi
-        if [[ ${{ inputs.cylc_rose }} == true ]]; then
-          if [[ ${{ inputs.editable_installations }} == true ]]; then
+        if ${{ inputs.cylc_rose }}; then
+          if ${{ inputs.editable_installations }}; then
             ARGS+=("--editable")
           fi
           ARGS+=("cylc-rose[${{ inputs.cylc_rose_opts }}]@git+https://github.com/${{ inputs.cylc_rose_repo }}@${cylc_rose}#egg=cylc-rose")
+        fi
+        if ! ${{ inputs.local_source }}; then
+          if ${{ inputs.editable_installations }}; then
+            ARGS+=("--editable")
+          fi
+          ARGS+=("${{ inputs.local_source }}")
         fi
 
         echo "pip install ${ARGS[@]}"

--- a/install-cylc-components/action.yml
+++ b/install-cylc-components/action.yml
@@ -156,7 +156,7 @@ runs:
           fi
           ARGS+=("cylc-rose[${{ inputs.cylc_rose_opts }}]@git+https://github.com/${{ inputs.cylc_rose_repo }}@${cylc_rose}#egg=cylc-rose")
         fi
-        if ! ${{ inputs.local_source }}; then
+        if [[ -n '${{ inputs.local_source }}' ]]; then
           if ${{ inputs.editable_installations }}; then
             ARGS+=("--editable")
           fi

--- a/install-cylc-components/action.yml
+++ b/install-cylc-components/action.yml
@@ -31,7 +31,7 @@ inputs:
       * `cylc_flow=True`.
       * `local_source=./metomi-rose`.
 
-      Dou may use `pip` options here, e.g: `-e=./metomi-rose[lint]`.
+      You may use `pip` options here, e.g: `-e=./metomi-rose[lint]`.
     default: false
     required: false
 

--- a/install-cylc-components/action.yml
+++ b/install-cylc-components/action.yml
@@ -32,7 +32,7 @@ inputs:
       * `local_source=./metomi-rose`.
 
       You may use `pip` options here, e.g: `-e=./metomi-rose[lint]`.
-    default: false
+    default: ''
     required: false
 
   cylc_flow:


### PR DESCRIPTION
#### Description

Add an option to allow a local source copy to be installed along with dependencies.

The motive here is to avoid the awkward 2-stage `pip install` where it's possible that the locally-installed source will be replaced, or cause a dependency to be replaced depending on order.

Context:
* https://github.com/metomi/rose/pull/3058#issuecomment-4789834857
* https://github.com/metomi/rose/pull/2632#issuecomment-4789832029

#### Checklist

- [x] I have read the contributing instructions in `README.md` and have opened this against the correct branch & milestone
