### PR TITLE
check-shortlog: ignore merge commits

### DIFF
--- a/check-shortlog/action.yml
+++ b/check-shortlog/action.yml
@@ -33,13 +33,13 @@ runs:
     - name: List commit authors
       shell: bash
       run: |
-        git shortlog -s HEAD \
+        git shortlog --no-merges -s HEAD \
             | awk '{$1=""; print substr($0,2) }' \
             | sort \
             | grep -v '\[bot\]' \
             > shortlog
         echo '::group::Commit authors:'
-        git shortlog -se HEAD
+        git shortlog --no-merges -se HEAD
         echo '::endgroup::'
 
     - name: See if they differ


### PR DESCRIPTION
* *Better* support users who set their commit name/email differently to what's configured in GitHub.
* This doesn't take away the issue completely, but does resolve false-positives caused by the merge created for CI to run on.